### PR TITLE
Target fedora-20 for juno release

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -7,7 +7,7 @@ releases:
   # overriden for each build target
   branch: master
   builds:
-  - dist: fedora-21
+  - dist: fedora-20
     buildsys: koji/master
   - dist: epel-7
     buildsys: copr/jruzicka/rdo-juno-epel-7


### PR DESCRIPTION
Looking at https://fedoraproject.org/wiki/Releases/21/Schedule
It looks like Fedora 21 won't get released until Nov 25th, which is after 
when we want RDO to be released, iiuc. So I assume we should be
targeting F20 for RDO Juno?
