### PR TITLE
Explicitly define the name of the os- packages

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -146,18 +146,22 @@ packages:
   maintainers:
   - jruzicka@redhat.com
 - project: os-apply-config
+  name: os-apply-config
   conf: core
   maintainers:
   - jruzicka@redhat.com
 - project: os-collect-config
+  name: os-collect-config
   conf: core
   maintainers:
   - jruzicka@redhat.com
 - project: os-refresh-config
+  name: os-refresh-config
   conf: core
   maintainers:
   - jruzicka@redhat.com
 - project: os-cloud-config
+  name: os-cloud-config
   conf: core
   maintainers:
   - jruzicka@redhat.com


### PR DESCRIPTION
Updates the configurations for os-apply-config, os-refresh-config,
os-collect-config, and os-cloud-config so that they are explicity
set. The 'core' template for these projects mostly works except
that the name field was previously wrong because these projects
don't have the 'openstack-' prefix on their RPMs.
