### PR TITLE
Add oslo.concurrency.

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -206,6 +206,9 @@ packages:
 - project: oslo-config
   conf: lib
   upstream: https://git.openstack.org/openstack/oslo.config
+- project: oslo-concurrency
+  conf: lib
+  upstream: https://git.openstack.org/openstack/oslo.concurrency
 - project: oslo-rootwrap
   conf: lib
   upstream: https://git.openstack.org/openstack/oslo.rootwrap


### PR DESCRIPTION
This is now required by Ironic. Initial RPM specs
here:

https://github.com/openstack-packages/python-oslo-concurrency

NOTE: There is an initial upstream doc fix that needs
to land before this will build:

 https://review.openstack.org/#/c/131862/

In order to build previously released versions we may need to
apply that patch. The upstream fix works fine w/ Delorean...
