### PR TITLE
Add openstacklib to openstack-puppet-modules.

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -290,6 +290,7 @@ packages:
     - https://github.com/derekhiggins/puppet-vlan.git
     - https://github.com/stackforge/puppet-vswitch.git
     - https://github.com/puppetlabs/puppetlabs-xinetd.git
+    - https://github.com/stackforge/puppet-openstacklib.git
   master-distgit: https://github.com/openstack-packages/openstack-puppet-modules.git
   maintainers:
   - mmagr@redhat.com


### PR DESCRIPTION
This is now required in order to use many of the upstream
stackforge puppet-*.
