### PR TITLE
Corrected maintainers for tuskar packages, added tuskar-ui-extras

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -152,11 +152,16 @@ packages:
 - project: tuskar
   conf: core
   maintainers:
-  - jruzicka@redhat.com
+  - jdobies@redhat.com
 - project: tuskar-ui
   conf: core
   maintainers:
-  - jruzicka@redhat.com
+  - jcoufal@redhat.com
+- project: tuskar-ui-extras
+  upstream: https://git.openstack.org/stackforge/tuskar-ui-extras
+  conf: core
+  maintainers:
+  - jcoufal@redhat.com
 - project: os-apply-config
   name: os-apply-config
   conf: core
@@ -197,6 +202,8 @@ packages:
   conf: client
 - project: tuskarclient
   conf: client
+  maintainers:
+  - jcoufal@redhat.com
 - project: cinderclient
   conf: client
 - project: ironicclient


### PR DESCRIPTION
I am on the mgt-health team, and we are tasked with making sure that the tuskar packages are getting packaged by delorean.

It looks like all but tuskar-ui-extras is already in rdoinfo, but the maintainers were not up to date. This patch sets the correct maintainers, and adds an entry for tuskar-ui-extras.