### PR TITLE
Replace agroup with rdo-management

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -163,12 +163,12 @@ packages:
   - jruzicka@redhat.com
 - project: instack
   conf: core
-  upstream: https://github.com/agroup/instack.git
+  upstream: https://github.com/rdo-management/instack.git
   maintainers:
   - jslagle@redhat.com
 - project: instack-undercloud
   conf: core
-  upstream: https://github.com/agroup/instack-undercloud.git
+  upstream: https://github.com/rdo-management/instack-undercloud.git
   maintainers:
   - jslagle@redhat.com
 - project: heat-templates


### PR DESCRIPTION
instack and instack-undercloud have now moved to the rdo-management org
on github for their official source repositories.