### PR TITLE
Add oslo-log package

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -267,6 +267,9 @@ packages:
 - project: oslo-context
   conf: lib
   upstream: https://git.openstack.org/openstack/oslo.context
+- project: oslo-log
+  conf: lib
+  upstream: https://git.openstack.org/openstack/oslo.log
 - project: stevedore
   conf: lib
   upstream: https://git.openstack.org/openstack/stevedore


### PR DESCRIPTION
Now required by keystone, packaging here
    https://github.com/openstack-packages/python-oslo-log