### PR TITLE
Add python-pycadf.

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -402,3 +402,8 @@ packages:
   master-distgit: https://github.com/openstack-packages/python-pysaml2.git
   maintainers:
   - apevec@redhat.com
+- name: python-pycadf
+  upstream: https://github.com/openstack/pycadf
+  master-distgit: https://github.com/openstack-packages/python-pycadf.git
+  maintainers:
+  - apevec@redhat.com


### PR DESCRIPTION
We need the latest python-pycadf RPM per recent keystone
dependencies upstream.