### PR TITLE
Add tripleo-puppet-elements

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -407,3 +407,7 @@ packages:
   master-distgit: https://github.com/openstack-packages/python-pycadf.git
   maintainers:
   - apevec@redhat.com
+- project: tripleo-puppet-elements
+  conf: core
+  maintainers:
+  - jslagle@redhat.com


### PR DESCRIPTION
tripleo-puppet-elements is a new project we need to package. Adding to rdo.yml. Can someone also create the repository under openstack-packages and set it up on gerrithub? I'll push up the initial packaging once that's done.