### PR TITLE
Add oslo.policy.

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -282,6 +282,9 @@ packages:
 - project: oslo-log
   conf: lib
   upstream: https://git.openstack.org/openstack/oslo.log
+- project: oslo-policy
+  conf: lib
+  upstream: https://git.openstack.org/openstack/oslo.policy
 - project: stevedore
   conf: lib
   upstream: https://git.openstack.org/openstack/stevedore


### PR DESCRIPTION
This is now required by keystone.