### PR TITLE
Do not chase trunk: six

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -292,13 +292,6 @@ packages:
   conf: lib
   upstream: https://git.openstack.org/openstack/stevedore
 # deps
-- name: python-six
-  project: six
-  upstream: hg::https://bitbucket.org/gutworth/six
-  distgit: ssh://pkgs.fedoraproject.org/python-%(name)s.git
-  master-distgit: https://github.com/openstack-packages/python-six.git
-  maintainers:
-  - mrunge@redhat.com
 - name: openstack-packstack
   project: packstack
   upstream: https://git.openstack.org/stackforge/packstack.git


### PR DESCRIPTION
six is not co-gated upstream, pypi releases are used: six>=1.9.0
Latest release 1.9.0 is avaible in RDO Kilo, also bkabrda pushed
updates in F20-22 https://admin.fedoraproject.org/updates/python-six