### PR TITLE
Add python-semantic-version

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -423,3 +423,9 @@ packages:
   conf: core
   maintainers:
   - jslagle@redhat.com
+- name: python-semantic-version
+  project: semanticversion
+  upstream: https://github.com/rbarrois/python-semanticversion.git
+  master-distgit: https://github.com/openstack-packages/python-semantic-version.git
+  maintainers:
+  - apevec@redhat.com


### PR DESCRIPTION
This is now required per Glance commit:
0dd1e32c67edb1d22a7ce86a084c81401b6ea8d2