### PR TITLE
Temporarily remove ironic

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -138,11 +138,6 @@ packages:
   maintainers:
   - eharney@redhat.com
   - apevec@redhat.com
-- project: ironic
-  conf: core
-  distro-branch: rpm-master
-  maintainers:
-  - athomas@redhat.com
 - project: neutron
   conf: core
   distro-branch: rpm-master


### PR DESCRIPTION
We've had problems with the delorean server becoming inaccessible and have
found a little evidence that it is linked to the build of ironic. Removing
it Temporarily to prove or disprove the theory.