### PR TITLE
Fix python-django-openstack-auth

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -173,6 +173,7 @@ packages:
 - project: django_openstack_auth
   conf: lib
   name: python-django-openstack-auth
+  master-distgit: git://github.com/openstack-packages/%(name)s
   maintainers:
   - mrunge@redhat.com
 - project: diskimage-builder


### PR DESCRIPTION
When using the lib conf, the master-distgit repo substitution was
wrong for this package.