### PR TITLE
Revert "Temporarily remove ironic"

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -132,6 +132,11 @@ packages:
   maintainers:
   - eharney@redhat.com
   - apevec@redhat.com
+- project: ironic
+  conf: core
+  distro-branch: rpm-master
+  maintainers:
+  - athomas@redhat.com
 - project: neutron
   conf: core
   maintainers:


### PR DESCRIPTION
Tripleo needs ironic in this repository in order to keep moving
forward and It looks like ironic didn't cause the problem we were
observing on the delorean server.

This reverts commit 8b1918e8565f5cd297b600063d2d5706fb00330e.