### PR TITLE
Add python-manilaclient

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -334,6 +334,8 @@ packages:
   conf: client
 - project: designateclient
   conf: client
+- project: manilaclient
+  conf: client
 - project: keystonemiddleware
   conf: client
   upstream: git://git.openstack.org/openstack/%(project)s

--- a/rdo.yml
+++ b/rdo.yml
@@ -117,6 +117,7 @@ package-configs:
     distro-branch: rpm-master
     maintainers:
     - jruzicka@redhat.com
+    - hguemar@redhat.com
   lib:
     name: python-%(project)s
     upstream: git://git.openstack.org/openstack/%(project)s
@@ -126,6 +127,7 @@ package-configs:
     distro-branch: rpm-master
     maintainers:
     - apevec@redhat.com
+    - hguemar@redhat.com
   xstatic:
     maintainers:
     - mrunge@redhat.com
@@ -174,6 +176,7 @@ packages:
   maintainers:
   - eharney@redhat.com
   - apevec@redhat.com
+  - hguemar@redhat.com
 - project: ironic
   conf: core
   distro-branch: rpm-master
@@ -217,7 +220,7 @@ packages:
   conf: core
   maintainers:
   - victoria@redhat.com
-  - hguemar@fedoraproject.org
+  - hguemar@redhat.com
 - project: django_openstack_auth
   conf: lib
   name: python-django-openstack-auth


### PR DESCRIPTION
Add python-manilaclient (all steps done)

```bash
$ delorean --config-file projects.ini --local --package-name python-manilaclient --dev  --info-repo /home/hguemar/rdoinfo/
INFO:delorean:Getting git://git.openstack.org/openstack/python-manilaclient to ./data/python-manilaclient
INFO:delorean:Processing python-manilaclient a30c30f8abe0f9e0fd7f5ed2eaa0d01af34b7ea9
$ ls data/repos/current/              
delorean.repo  installed  python-manilaclient-1.2.0-post7.fc21.noarch.rpm  python-manilaclient-1.2.0-post7.fc21.src.rpm  python-manilaclient-doc-1.2.0-post7.fc21.noarch.rpm  repodata  rpmbuild.log
```
Add myself to notifications for cinder, clients and python libs
