### PR TITLE
Import Zaqar in Delorean

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -307,8 +307,13 @@ packages:
 - project: manila
   conf: core
   maintainers:
-  - hguemar@fedoraproject.org
+  - hguemar@redhat.com
   - zaitcev@redhat.com
+- project: zaqar
+  conf: core
+  maintainers:
+  - hguemar@redhat.com
+  - fpercoco@redhat.com
 # The openstack clients
 - project: keystoneclient
   conf: client


### PR DESCRIPTION
Please @flaper87 review changes.

```bash
 $ delorean --config-file projects.ini --local --package-name openstack-zaqar --dev  --info-repo /home/hguemar/rdoinfo/    
INFO:delorean:Getting git://github.com/openstack-packages/zaqar to ./data/openstack-zaqar_distro
INFO:delorean:Getting git://git.openstack.org/openstack/zaqar to ./data/openstack-zaqar
INFO:delorean:Processing openstack-zaqar 8919f5af6faaf839a42c0d9c49bf53259cf966ac
$ ls -l data/repos/89/19/8919f5af6faaf839a42c0d9c49bf53259cf966ac_dev/
total 1064
-rw-r--r--. 1 hguemar hguemar    204 Jun 12 23:06 delorean.repo
-rw-r--r--. 1 hguemar hguemar   2063 Jun 12 23:05 distro_delta.diff
-rw-r--r--. 1 hguemar hguemar      0 Jun 12 23:06 installed
-rw-r--r--. 1 hguemar hguemar 451924 Jun 12 23:06 openstack-zaqar-2015.2-dev62.fc21.noarch.rpm
-rw-r--r--. 1 hguemar hguemar 427118 Jun 12 23:06 openstack-zaqar-2015.2-dev62.fc21.src.rpm
drwxr-xr-x. 2 hguemar hguemar   4096 Jun 12 23:06 repodata
-rw-r--r--. 1 hguemar hguemar 191324 Jun 12 23:06 rpmbuild.log

```