### PR TITLE
Fix location of networking-odl

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -455,7 +455,7 @@ packages:
   - motyz@mellanox.com
 - project: networking-odl
   name: python-networking-odl
-  upstream: git://git.openstack.org/stackforge/%(project)s
+  upstream: git://git.openstack.org/openstack/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
   distro-branch: rpm-master
   maintainers:


### PR DESCRIPTION
It has moved from stackforge to the openstack tree.