### PR TITLE
Adding networking-cisco to rdo.yml

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -472,10 +472,11 @@ packages:
 - project: networking-cisco
   name: python-networking-cisco
   upstream: git://git.openstack.org/openstack/%(project)s
-  master-distgit: git://github.com/bdemers/networking-cisco-packages
+  master-distgit: git://github.com/openstack-packages/%(name)s
   distro-branch: rpm-master
   maintainers:
   - openstack-networking@cisco.com
+  - brdemers@cisco.com
 - project: tripleo-puppet-elements
   conf: core
   maintainers:

--- a/rdo.yml
+++ b/rdo.yml
@@ -469,6 +469,13 @@ packages:
   maintainers:
   - ihrachys@redhat.com
   - majopela@redhat.com
+- project: networking-cisco
+  name: networking-cisco
+  upstream: git://git.openstack.org/openstack/%(project)s
+  master-distgit: git://github.com/bdemers/networking-cisco-packages
+  distro-branch: rpm-master
+  maintainers:
+  - openstack-networking@cisco.com
 - project: tripleo-puppet-elements
   conf: core
   maintainers:

--- a/rdo.yml
+++ b/rdo.yml
@@ -470,7 +470,7 @@ packages:
   - ihrachys@redhat.com
   - majopela@redhat.com
 - project: networking-cisco
-  name: networking-cisco
+  name: python-networking-cisco
   upstream: git://git.openstack.org/openstack/%(project)s
   master-distgit: git://github.com/bdemers/networking-cisco-packages
   distro-branch: rpm-master


### PR DESCRIPTION
This pull request serves as a little more then just updating `rdo.yml`

I've added a spec repo here [networking-cisco-packages](https://github.com/bdemers/networking-cisco-packages) which hopefully would be moved to openstack-packages/python-networking-cisco

Please have a look at both the `rdo.yml` and [networking-cisco-packages](https://github.com/bdemers/networking-cisco-packages) let me know what you think.

**Update:** openstack-packages/python-networking-cisco as added