### PR TITLE
Adds the octavia package

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -207,6 +207,10 @@ packages:
   maintainers:
   - ihrachys@redhat.com
   - majopela@redhat.com
+- project: octavia
+  conf: core
+  maintainers:
+  - nmagnezi@redhat.com
 - project: sahara
   conf: core
   maintainers:


### PR DESCRIPTION
We'll need to package octavia for the Liberty release.
distro files (and spec among them) can temporarily be found here: https://github.com/nmagnezi/openstack-octavia_distro