### PR TITLE
Adding python-UcsSdk to rdo.yml

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -490,6 +490,14 @@ packages:
   maintainers:
   - openstack-networking@cisco.com
   - brdemers@cisco.com
+- project: UcsSdk
+  name: python-%(project)s
+  upstream: git://github.com/CiscoUcs/UcsPythonSDK
+  master-distgit: git://github.com/bdemers/python-UcsSdk-spec
+  distro-branch: rpm-master
+  maintainers:
+  - openstack-networking@cisco.com
+  - brdemers@cisco.com
 - project: tripleo-puppet-elements
   conf: core
   maintainers:


### PR DESCRIPTION
**Do not merge**

So... openstack/networking-cisco _should_ depend on UcsSdk (https://review.openstack.org/#/c/196861/4/requirements.txt)

*background* - UcsSdk, is a python lib that communicates/configures Cisco UCS's

There is no RPM for this lib yet.
@morazi mentioned including this lib inside of the python-networking-cisco rpm.  That is fine with me, I'm just not sure how to get the 2nd tarball into delorean short of adding a binary file to git...

So to move the discussion along I created bdemers/python-UcsSdk-spec
moved to openstack-packages/python-UcsSdk

This goes against the [naming recommendations](https://www.rdoproject.org/packaging/rdo-packaging.html) UcsPythonSdk vs UcsSdk. But the actual python module is [UcsSdk](https://pypi.python.org/pypi/UcsSdk)

@booxter @apevec Thoughts on moving forward ?  How would this get rolled into python-networking-cisco ?



