### PR TITLE
Pull rdo-manager, instack-undercloud and dep into delorean/master

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -262,6 +262,11 @@ packages:
   conf: core
   maintainers:
   - jruzicka@redhat.com
+- project: tuskar-ui-extras
+  conf: core
+  upstream: https://github.com/rdo-management/tuskar-ui-extras
+  maintainers:
+  - jtomasek@redhat.com
 - project: instack
   conf: core
   name: instack
@@ -318,6 +323,12 @@ packages:
   maintainers:
   - hguemar@redhat.com
   - fpercoco@redhat.com
+- project: ironic-discoverd
+  conf: core
+  upstream: https://github.com/rdo-management/ironic-discoverd
+  source-branch: mgt-master
+  maintainers:
+  - dtantsur@redhat.com
 # The openstack clients
 - project: keystoneclient
   conf: client
@@ -353,6 +364,15 @@ packages:
   upstream: git://git.openstack.org/openstack/%(project)s
 - project: openstackclient
   conf: client
+- project: ironic-inspector-client
+  conf: client
+  maintainers:
+  - dtantsur@redhat.com
+- project: rdomanager-oscplugin
+  conf: client
+  upstream: https://github.com/rdo-management/python-rdomanager-oscplugin
+  maintainers:
+  - brad@redhat.com
 # openstack libraries
 - project: oslo-sphinx
   conf: lib
@@ -438,6 +458,11 @@ packages:
   - apevec@gmail.com
   - gchamoul@redhat.com
   - jpena@redhat.com
+- project: tripleo-common
+  conf: core
+  name: tripleo-common
+  maintainers:
+  - jprovazn@redhat.com
 - project: osprofiler
   name: python-osprofiler
   upstream: git://git.openstack.org/stackforge/%(project)s


### PR DESCRIPTION
This move was discussed here http://lists.openstack.org/pipermail/openstack-dev/2015-July/070140.html

We're in the process of moving all of these projects upstream under
the tripleo umbrella so they should be the the delorean repository.

Once they are pulled upstream we can remove all the links to the
rdo-management github organization.