### PR TITLE
Add python-alembic

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -583,3 +583,9 @@ packages:
 - project: unicodecsv
   conf: lib
   upstream: git://github.com/jdunck/python-unicodecsv
+- name: python-alembic
+  project: alembic
+  upstream: https://bitbucket.org/zzzeek/alembic.git
+  master-distgit: https://github.com/openstack-packages/python-alembic.git
+  maintainers:
+  - apevec@redhat.com


### PR DESCRIPTION
neutron now requires a newer version of this than what is in rdo/kilo,
add it explicitly to rdoinfo until we are requiring rdo/liberty.