### PR TITLE
Rename rdomanager-oscplugin to tripleoclient

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -410,9 +410,8 @@ packages:
   conf: client
   maintainers:
   - dtantsur@redhat.com
-- project: rdomanager-oscplugin
+- project: tripleoclient
   conf: client
-  upstream: https://github.com/rdo-management/python-rdomanager-oscplugin
   maintainers:
   - brad@redhat.com
 # openstack libraries


### PR DESCRIPTION
Upstream this project has been moved and renamed.