### PR TITLE
Get instack and instack undercloud from their new homes

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -307,13 +307,11 @@ packages:
 - project: instack
   conf: core
   name: instack
-  upstream: git://github.com/rdo-management/%(project)s
   maintainers:
   - jslagle@redhat.com
 - project: instack-undercloud
   conf: core
   name: instack-undercloud
-  upstream: git://github.com/rdo-management/%(project)s
   maintainers:
   - jslagle@redhat.com
 - project: heat-templates


### PR DESCRIPTION
These have been moved to git.openstack.org.