### PR TITLE
Add ironic-inspector to delorean

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -358,11 +358,10 @@ packages:
   maintainers:
   - hguemar@redhat.com
   - fpercoco@redhat.com
-- project: ironic-discoverd
+- project: ironic-inspector
   conf: core
-  upstream: https://github.com/rdo-management/ironic-discoverd
-  source-branch: mgt-master
   maintainers:
+  - trown@redhat.com
   - dtantsur@redhat.com
 - project: ironic-python-agent
   conf: core


### PR DESCRIPTION
This is a rename of ironic-discoverd for liberty, so we do not need to build ironic-discoverd anymore.