### PR TITLE
Pin os-client-config to the last known version without keystoneauth dep

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -344,8 +344,9 @@ packages:
   maintainers:
   - jruzicka@redhat.com
 - project: os-client-config
-  conf: core
-  name: os-client-config
+  conf: lib
+  upstream: git://github.com/redhat-openstack/%(project)s
+  source-branch: pin-to-1.6.4
   maintainers:
   - jruzicka@redhat.com
 - project: manila


### PR DESCRIPTION
Details in https://www.redhat.com/archives/rdo-list/2015-September/msg00164.html

Also rename it to python-* as a first step to sync with Fedora Rawhide.