### PR TITLE
Add python-ceilometermiddleware

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -402,6 +402,9 @@ packages:
 - project: keystonemiddleware
   conf: client
   upstream: git://git.openstack.org/openstack/%(project)s
+- project: ceilometermiddleware
+  conf: client
+  upstream: git://git.openstack.org/openstack/%(project)s
 - project: openstackclient
   conf: client
 - project: ironic-inspector-client


### PR DESCRIPTION
Builds in delorean
```bash
 % delorean --config-file projects.ini --package-name python-ceilometermiddleware --info-repo ~/.rdopkg/rdoinfo --local --dev
INFO:delorean:Getting git://git.openstack.org/openstack/ceilometermiddleware to ./data/python-ceilometermiddleware
INFO:delorean:Processing python-ceilometermiddleware 7005d98f47be809243d627cee7ca594390cddec2
% ls -l data/repos/70/05/7005d98f47be809243d627cee7ca594390cddec2_dev/*.rpm(^@)
-rw-r--r--. 1 hguemar hguemar 27004 Sep 19 01:29 data/repos/70/05/7005d98f47be809243d627cee7ca594390cddec2_dev/python-ceilometermiddleware-0.3.0-0.99.20150918.2327git.fc22.noarch.rpm
-rw-r--r--. 1 hguemar hguemar 21696 Sep 19 01:29 data/repos/70/05/7005d98f47be809243d627cee7ca594390cddec2_dev/python-ceilometermiddleware-0.3.0-0.99.20150918.2327git.fc22.src.rpm
```

No duplicate in rdo.yml
```bash
git grep ceilometermiddleware
rdo.yml:- project: ceilometermiddleware
```