### PR TITLE
unpin os-client-config

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -345,8 +345,6 @@ packages:
   - jruzicka@redhat.com
 - project: os-client-config
   conf: lib
-  upstream: git://github.com/redhat-openstack/%(project)s
-  source-branch: pin-to-1.6.4
   maintainers:
   - jruzicka@redhat.com
 - project: manila


### PR DESCRIPTION
upstream issue has been fixed in 1.7.4
https://bugs.launchpad.net/os-client-config/+bug/1496689