### PR TITLE
Remove explict distro-branch from rdoinfo

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -141,14 +141,12 @@ package-configs:
     distgit: ssh://pkgs.fedoraproject.org/openstack-%(project)s.git
     patches: git://github.com/redhat-openstack/%(project)s
     master-distgit: git://github.com/openstack-packages/%(project)s
-    distro-branch: rpm-master
   client:
     name: python-%(project)s
     upstream: git://git.openstack.org/openstack/python-%(project)s
     distgit: ssh://pkgs.fedoraproject.org/python-%(project)s.git
     patches: git://github.com/redhat-openstack/python-%(project)s
     master-distgit: git://github.com/openstack-packages/python-%(project)s
-    distro-branch: rpm-master
     maintainers:
     - jruzicka@redhat.com
     - hguemar@redhat.com
@@ -158,7 +156,6 @@ package-configs:
     distgit: ssh://pkgs.fedoraproject.org/python-%(project)s.git
     patches: git://github.com/redhat-openstack/%(project)s
     master-distgit: git://github.com/openstack-packages/python-%(project)s
-    distro-branch: rpm-master
     maintainers:
     - apevec@redhat.com
     - hguemar@redhat.com
@@ -199,7 +196,6 @@ packages:
   - chdent@redhat.com
 - project: gnocchi
   conf: core
-  distro-branch: rpm-master
   maintainers:
   - pkilambi@redhat.com
   - chdent@redhat.com
@@ -216,7 +212,6 @@ packages:
   - hguemar@redhat.com
 - project: ironic
   conf: core
-  distro-branch: rpm-master
   maintainers:
   - athomas@redhat.com
 - project: neutron
@@ -375,7 +370,6 @@ packages:
 # The openstack clients
 - project: keystoneclient
   conf: client
-  distro-branch: rpm-master
 - project: glanceclient
   conf: client
 - project: novaclient
@@ -510,7 +504,6 @@ packages:
   patches: git://github.com/redhat-openstack/%(project)s
   distgit: ssh://pkgs.fedoraproject.org/%(name)s
   master-distgit: git://github.com/openstack-packages/%(project)s
-  distro-branch: rpm-master
   maintainers:
   - mmagr@redhat.com
   - lbezdick@redhat.com
@@ -519,7 +512,6 @@ packages:
   upstream: git://github.com/redhat-openstack/%(name)s
   source-branch: master-patches
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - apevec@gmail.com
   - gchamoul@redhat.com
@@ -533,14 +525,12 @@ packages:
   name: python-osprofiler
   upstream: git://git.openstack.org/stackforge/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - apevec@redhat.com
 - project: pysaml2
   name: python-%(project)s
   upstream: git://github.com/rohe/pysaml2
   master-distgit: git://github.com/openstack-packages/python-pysaml2
-  distro-branch: rpm-master
   maintainers:
   - apevec@redhat.com
 - project: appdirs
@@ -553,7 +543,6 @@ packages:
   name: python-networking-arista
   upstream: git://git.openstack.org/openstack/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - ihrachys@redhat.com
   - majopela@redhat.com
@@ -561,7 +550,6 @@ packages:
   name: python-networking-mlnx
   upstream: git://git.openstack.org/stackforge/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - ihrachys@redhat.com
   - motyz@mellanox.com
@@ -569,7 +557,6 @@ packages:
   name: python-networking-odl
   upstream: git://git.openstack.org/openstack/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - ihrachys@redhat.com
   - majopela@redhat.com
@@ -577,14 +564,12 @@ packages:
   name: python-networking-vmware-nsx
   upstream: git://git.openstack.org/openstack/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - ihrachys@redhat.com
 - project: networking-bigswitch
   name: python-networking-bigswitch
   upstream: git://git.openstack.org/stackforge/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - ihrachys@redhat.com
   - xin.wu@bigswitch.com
@@ -592,7 +577,6 @@ packages:
   name: python-networking-cisco
   upstream: git://git.openstack.org/openstack/%(project)s
   master-distgit: git://github.com/openstack-packages/%(name)s
-  distro-branch: rpm-master
   maintainers:
   - openstack-networking@cisco.com
   - brdemers@cisco.com


### PR DESCRIPTION
This is will allow master rdoinfo to be used by Delorean instances
building from stable/* branches by specifying distro= and source=
parameters in projects.ini using proposed Delorean change https://review.gerrithub.io/248584