### PR TITLE
Add aodh

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -199,6 +199,11 @@ packages:
   maintainers:
   - pkilambi@redhat.com
   - chdent@redhat.com
+- project: aodh
+  conf: core
+  maintainers:
+  - pkilambi@redhat.com
+  - chdent@redhat.com
 - project: heat
   conf: core
   maintainers:


### PR DESCRIPTION
Builds in delorean
```bash
% delorean --config-file projects-centos.ini --package-name openstack-aodh --info-repo ~/.rdopkg/rdoinfo --local --dev    
INFO:delorean:Getting git://git.openstack.org/openstack/aodh to ./data/openstack-aodh
INFO:delorean:Processing openstack-aodh 835120997071fce3e2731574c4060c53e64166f5
% ls data/repos/current 
build.log      openstack-aodh-0.0.1-dev4127.el7.centos.src.rpm            openstack-aodh-evaluator-0.0.1-dev4127.el7.centos.noarch.rpm  python-aodh-0.0.1-dev4127.el7.centos.noarch.rpm  state.log
delorean.repo  openstack-aodh-api-0.0.1-dev4127.el7.centos.noarch.rpm     openstack-aodh-expirer-0.0.1-dev4127.el7.centos.noarch.rpm    repodata
installed      openstack-aodh-common-0.0.1-dev4127.el7.centos.noarch.rpm  openstack-aodh-listener-0.0.1-dev4127.el7.centos.noarch.rpm   root.log
mock.log       openstack-aodh-compat-0.0.1-dev4127.el7.centos.noarch.rpm  openstack-aodh-notifier-0.0.1-dev4127.el7.centos.noarch.rpm   rpmbuild.log
```