### PR TITLE
Fix tripleo-incubator

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -278,7 +278,8 @@ packages:
   name: dib-utils
   maintainers:
   - jruzicka@redhat.com
-- project: tripleo
+- project: tripleo-incubator
+  name: openstack-tripleo
   conf: core
   upstream: git://git.openstack.org/openstack/tripleo-incubator
   maintainers:


### PR DESCRIPTION
We need the project name to be tripleo-incubator in order
for the delorean map-project-name script to map the upstream
project name to the rpm package name.

Without this tripleoci is unable to build the openstack-tripleo
package.