### PR TITLE
Fix tripleo-incubator distgit URLs

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -281,7 +281,8 @@ packages:
 - project: tripleo-incubator
   name: openstack-tripleo
   conf: core
-  upstream: git://git.openstack.org/openstack/tripleo-incubator
+  distgit: ssh://pkgs.fedoraproject.org/openstack-tripleo.git
+  master-distgit: git://github.com/openstack-packages/tripleo
   maintainers:
   - jslagle@redhat.com
 - project: tripleo-heat-templates


### PR DESCRIPTION
Changing the project name for tripleo-incubator to make the
map-packages work, had the unitended consequence of breaking
the distgit urls, since they include the project name when using
conf=core.