### PR TITLE
Update python-os-brick information

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -565,8 +565,9 @@ packages:
   - jslagle@redhat.com
 - project: os-brick
   name: python-os-brick
-  conf: core
-  name: os-brick
+  conf: lib
+  upstream: git://git.openstack.org/openstack/%(project)s
+  master-distgit: git://github.com/openstack-packages/%(project)s
   maintainers:
   - eharney@redhat.com
   - jpena@redhat.com


### PR DESCRIPTION
https://review.gerrithub.io/250647 changed the spec file name from
os-brick.spec to python-os-brick.spec. This was confusing delorean
when executed with --order.