### PR TITLE
Add mistral

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -632,3 +632,7 @@ packages:
   conf: client
   maintainers:
   - hguemar@redhat.com
+- project: mistral
+  conf: core
+  maintainers:
+  - hguemar@redhat.com


### PR DESCRIPTION
Builds but doesn't functionally work yet due to missing python2-yaql
>= 1.0.0 dependency. Also, docs are currently disable due to a missing
docs package for sphinxcontrib-pecanswme.