### PR TITLE
Fix horizon configuration

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -232,6 +232,7 @@ packages:
 - project: horizon
   conf: core
   name: python-django-horizon
+  distgit: ssh://pkgs.fedoraproject.org/python-django-%(project)s.git
   maintainers:
   - mrunge@redhat.com
 - project: trove


### PR DESCRIPTION
rdopkg clone fails due to horizon package having a non-predictible name