### PR TITLE
Add python-cloudkittyclient package

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -380,6 +380,10 @@ packages:
   - greg.swift@rackspace.net
   - msm@redhat.com
   - chkumar@redhat.com
+- project: cloudkittyclient
+  conf: client
+  maintainers:
+  - gauvain.pocentek@objectif-libre.com
 - project: keystonemiddleware
   conf: client
   upstream: git://git.openstack.org/openstack/%(project)s


### PR DESCRIPTION
The packaging repo is available here: https://github.com/ObjectifLibre/python-cloudkittyclient

The delorean build with this setup is successful.