### PR TITLE
Implement OpenStack in Fedora conclusions

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -4,38 +4,19 @@
 releases:
 - name: liberty
   # this is default branch for release and can be overriden on repo level
-  branch: master
-  fedora: 24/rawhide
+  branch: rdo-liberty
   repos:
-  - name: f23
-    buildsys: koji/master
-    distrepos:
-    - name: RDO Liberty f23
-      url: https://rdoproject.org/repos/openstack-liberty/testing/f23/
-    - name: Fedora 23 Development
-      url: http://download.fedoraproject.org/pub/fedora/development/23/x86_64/os/
-  - name: f22
-    special: symlink to fedora-23 repo (don't submit fedora-22 Liberty updates)
-    distrepos:
-    - name: RDO Liberty f22
-      url: https://rdoproject.org/repos/openstack-liberty/testing/f22/
-    - name: Fedora 22 Updates
-      url: http://download.fedoraproject.org/pub/fedora/linux/updates/22/x86_64/
-    - name: Fedora 22
-      url: http://download.fedoraproject.org/pub/fedora/linux/releases/22/Everything/x86_64/os/
   - name: el7
     buildsys: cbs/cloud7-openstack-liberty-el7
     distrepos:
     - name: RDO Liberty el7
-      url: https://rdoproject.org/repos/openstack-liberty/testing/el7/
+      url: https://rdoproject.org/repos/openstack-liberty/el7/
     - name: CentOS 7 Base
       url: http://mirror.centos.org/centos/7/os/x86_64/
     - name: CentOS 7 Updates
       url: http://mirror.centos.org/centos/7/updates/x86_64/
     - name: CentOS 7 Extras
       url: http://mirror.centos.org/centos/7/extras/x86_64/
-    - name: EPEL 7
-      url: http://dl.fedoraproject.org/pub/epel/7/x86_64/
 - name: kilo
   # this is default branch for release and can be overriden on repo level
   branch: f23
@@ -115,7 +96,8 @@ package-configs:
   core:
     name: openstack-%(project)s
     upstream: git://git.openstack.org/openstack/%(project)s
-    distgit: ssh://pkgs.fedoraproject.org/openstack-%(project)s.git
+    # Current distgit for RDO Liberyt is rdo-liberty branch
+    distgit: git://github.com/openstack-packages/%(project)s
     patches: git://github.com/redhat-openstack/%(project)s
     master-distgit: git://github.com/openstack-packages/%(project)s
   client:


### PR DESCRIPTION
https://trello.com/c/wzdl1IlZ/52-openstack-in-fedora
* RDO Liberty repo is EL7 only
* distgit moves to openstack-packages rdo-liberty branch
* clients stay in Fedora proper