### PR TITLE
Remove special case for OPM

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -488,7 +488,6 @@ packages:
 - project: openstack-puppet-modules
   name: openstack-puppet-modules
   upstream: git://github.com/redhat-openstack/%(name)s
-  source-branch: master-patches
   master-distgit: git://github.com/openstack-packages/%(name)s
   maintainers:
   - apevec@gmail.com

--- a/rdo.yml
+++ b/rdo.yml
@@ -650,3 +650,8 @@ packages:
   maintainers:
   - apevec@redhat.com
   - pkilambi@redhat.com
+- project: reno
+  conf: lib
+  maintainers:
+  - chkumar@redhat.com
+  - jpena@redhat.com


### PR DESCRIPTION
The openstack-puppet-modules repo has changed its branches to match
the rest of the OpenStack projects, so there is no need to use
master-patches anymore. We now have master and stable/liberty with
the appropriate content.