### PR TITLE
Adding cisco-ironic-contrib to rdo

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -572,7 +572,7 @@ packages:
 - project: cisco-ironic-contrib
   name: python-ironic-cisco
   upstream: git://git.openstack.org/openstack/%(project)s
-  master-distgit: git://github.com/bdemers/%(name)s
+  master-distgit: git://github.com/openstack-pacakges/%(name)s
   maintainers:
   - openstack-networking@cisco.com
   - brdemers@cisco.com

--- a/rdo.yml
+++ b/rdo.yml
@@ -569,6 +569,13 @@ packages:
   maintainers:
   - openstack-networking@cisco.com
   - brdemers@cisco.com
+- project: cisco-ironic-contrib
+  name: python-ironic-cisco
+  upstream: git://git.openstack.org/openstack/%(project)s
+  master-distgit: git://github.com/bdemers/%(name)s
+  maintainers:
+  - openstack-networking@cisco.com
+  - brdemers@cisco.com
 - project: tripleo-puppet-elements
   conf: core
   maintainers:


### PR DESCRIPTION
Couple open items:

~~1. Package name:
Doc suggests the package name should be 'python-cisco-ironic-contrib' but... to me that implies incorrect ownership.  And does NOT match other openstack naming (networking-*, fuel-plugin-*, etc)
I've named the package python-ironic-cisco, but I'll change it if needed.~~

~~1. Create a spec repo in openstack-packages (once the above issue is resolved)~~

python-ironic-cisco has been imported to: openstack-packages/python-ironic-cisco

