### PR TITLE
Fix some wrong definitions

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -154,10 +154,13 @@ packages:
 - project: glance_store
   conf: core
   name: python-glance-store
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - hguemar@redhat.com
 - project: swift
   conf: core
+  name: openstack-swift
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - zaitcev@redhat.com
 - project: ceilometer
@@ -238,6 +241,7 @@ packages:
 - project: django_openstack_auth
   conf: lib
   name: python-django-openstack-auth
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   master-distgit: git://github.com/openstack-packages/%(name)s
   maintainers:
   - mrunge@redhat.com
@@ -249,6 +253,7 @@ packages:
 - project: dib-utils
   conf: core
   name: dib-utils
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - jruzicka@redhat.com
 - project: tripleo-incubator
@@ -283,26 +288,31 @@ packages:
 - project: os-apply-config
   conf: core
   name: os-apply-config
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - jruzicka@redhat.com
 - project: os-collect-config
   conf: core
   name: os-collect-config
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - jruzicka@redhat.com
 - project: os-net-config
   conf: core
   name: os-net-config
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - dprince@redhat.com
 - project: os-refresh-config
   conf: core
   name: os-refresh-config
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - jruzicka@redhat.com
 - project: os-cloud-config
   conf: core
   name: os-cloud-config
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - jruzicka@redhat.com
 - project: os-client-config
@@ -322,6 +332,7 @@ packages:
   - zaitcev@redhat.com
 - project: zaqar
   conf: core
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - hguemar@redhat.com
   - fpercoco@redhat.com
@@ -332,6 +343,7 @@ packages:
   - dtantsur@redhat.com
 - project: ironic-python-agent
   conf: core
+  distgit: ssh://pkgs.fedoraproject.org/%(name)s.git
   maintainers:
   - trown@redhat.com
   - dtantsur@redhat.com


### PR DESCRIPTION
For projects below distgit is located on pkg.fedoraproject.org
(at least for liberty):

* glance_store
* swift
* dib-utils
* os-apply-config
* os-collect-config
* os-net-config
* os-refresh-config
* os-cloud-config
* zaqar
* ironic-python-agent

Wrong name is used to define the distgit target for:

* django_openstack_auth: