### PR TITLE
Add missing gnocchiclient

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -417,6 +417,10 @@ packages:
   - fpercoco@redhat.com
 - project: openstacksdk
   conf: client
+- project: gnocchiclient
+  conf: client
+  maintainers:
+  - pkilambi@redhat.com
 # openstack libraries
 - project: mox3
   conf: lib


### PR DESCRIPTION
```bash
% delorean --config projects.ini --package-name python-gnocchiclient --local --dev
INFO:delorean:Getting git://github.com/openstack-packages/python-gnocchiclient to ./data/python-gnocchiclient_distro
INFO:delorean:Getting git://git.openstack.org/openstack/python-gnocchiclient to ./data/python-gnocchiclient
INFO:delorean:Processing python-gnocchiclient b32b59d5d581527b742d78995725915dcd02b871
```