### PR TITLE
tags: gnocchi is liberty and mitaka only

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -168,6 +168,10 @@ packages:
   - mabaakou@redhat.com
 - project: gnocchi
   conf: core
+  tags:
+    mitaka:
+    liberty:
+      source-branch: stable/1.3
   maintainers:
   - pkilambi@redhat.com
   - mabaakou@redhat.com


### PR DESCRIPTION
Also does not follow stable/liberty branch naming, so override it to
use gnocchi 1.3 branch for Liberty builds.

Depends on Delorean change https://review.gerrithub.io/262359