### PR TITLE
Set source-branch for kilo version of OPM

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -671,6 +671,11 @@ packages:
   - lbezdick@redhat.com
   - ichavero@redhat.com
 - project: openstack-puppet-modules
+  tags:
+    mitaka:
+    liberty:
+    kilo:
+      source-branch: kilo
   name: openstack-puppet-modules
   upstream: git://github.com/redhat-openstack/%(name)s
   master-distgit: git://github.com/openstack-packages/%(name)s


### PR DESCRIPTION
As opposed to Liberty (stable/liberty), the Kilo branch is kilo.