### PR TITLE
Remove OPM tags

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -671,11 +671,6 @@ packages:
   - lbezdick@redhat.com
   - ichavero@redhat.com
 - project: openstack-puppet-modules
-  tags:
-    mitaka:
-    liberty:
-    kilo:
-      source-branch: f23-patches
   name: openstack-puppet-modules
   upstream: git://github.com/redhat-openstack/%(name)s
   master-distgit: git://github.com/openstack-packages/%(name)s


### PR DESCRIPTION
OPM now has a stable/kilo branch, so tags are no longer needed.