### PR TITLE
ironic-python-agent is actually branchless

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -413,6 +413,7 @@ packages:
   tags:
     mitaka:
     liberty:
+      source-branch: master
   conf: core
   maintainers:
   - trown@redhat.com


### PR DESCRIPTION
stable/liberty for i-p-a was historical misunderstanding:
http://lists.openstack.org/pipermail/openstack-dev/2016-February/086985.html