### PR TITLE
Set proper branches for Tempest package

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -813,10 +813,11 @@ packages:
 - project: tempest
   tags:
     mitaka:
+      source-branch: master
     liberty:
+      source-branch: liberty
   conf: core
   upstream: git://github.com/redhat-openstack/tempest.git
-  source-branch: rebased-upstream
   maintainers:
   - slinaber@redhat.com
   - dmellado@redhat.com


### PR DESCRIPTION
Now the package will use "master" for master packaging, and "liberty"
for stable/liberty.