### PR TITLE
Releases spring cleanup

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -10,7 +10,7 @@ releases:
     buildsys: cbs/cloud7-openstack-liberty-el7
     distrepos:
     - name: RDO Liberty el7
-      url: https://rdoproject.org/repos/openstack-liberty/el7/
+      url: http://mirror.centos.org/centos/7/cloud/x86_64/openstack-liberty/
     - name: CentOS 7 Base
       url: http://mirror.centos.org/centos/7/os/x86_64/
     - name: CentOS 7 Updates
@@ -22,73 +22,17 @@ releases:
   branch: f23
   fedora: 23
   repos:
-  - name: f22
-    buildsys: koji/master
-    distrepos:
-    - name: RDO Kilo f22
-      url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/f22/
-    - name: Fedora 22 Updates
-      url: http://download.fedoraproject.org/pub/fedora/linux/updates/22/x86_64/
-    - name: Fedora 22
-      url: http://download.fedoraproject.org/pub/fedora/linux/releases/22/Everything/x86_64/os/
-  - name: f21
-    special: symlink to fedora-22 repo (don't submit fedora-21 updates)
-    distrepos:
-    - name: RDO Kilo f21
-      url: https://repos.fedorapeople.org/repos/openstack/openstack-kilo/f21/
-    - name: Fedora 21 Updates
-      url: http://download.fedoraproject.org/pub/fedora/linux/updates/21/x86_64/
-    - name: Fedora 21
-      url: http://download.fedoraproject.org/pub/fedora/linux/releases/21/Everything/x86_64/os/
   - name: el7
     buildsys: cbs/cloud7-openstack-kilo-el7
     distrepos:
     - name: RDO Kilo el7
-      url: http://repos.fedorapeople.org/repos/openstack/openstack-kilo/el7/
+      url: http://mirror.centos.org/centos/7/cloud/x86_64/openstack-kilo/
     - name: CentOS 7 Base
       url: http://mirror.centos.org/centos/7/os/x86_64/
     - name: CentOS 7 Updates
       url: http://mirror.centos.org/centos/7/updates/x86_64/
     - name: CentOS 7 Extras
       url: http://mirror.centos.org/centos/7/extras/x86_64/
-    - name: EPEL 7
-      url: http://dl.fedoraproject.org/pub/epel/7/x86_64/
-- name: juno
-  # this is default branch for release and can be overriden on repo level
-  branch: f22
-  fedora: 22
-  repos:
-  - name: fedora-21
-    buildsys: koji/f22
-    distrepos:
-    - name: RDO Juno fedora-21
-      url: https://repos.fedorapeople.org/repos/openstack/openstack-juno/fedora-21/
-    - name: Fedora 21 Updates
-      url: http://download.fedoraproject.org/pub/fedora/linux/updates/21/x86_64/
-    - name: Fedora 21
-      url: http://download.fedoraproject.org/pub/fedora/linux/releases/21/Everything/x86_64/os/
-  - name: fedora-20
-    special: symlink to fedora-21 repo (don't submit fedora-20 updates)
-    distrepos:
-    - name: RDO Juno fedora-20
-      url: https://repos.fedorapeople.org/repos/openstack/openstack-juno/fedora-20/
-    - name: Fedora 20 Updates
-      url: http://dl.fedoraproject.org/pub/fedora/linux/updates/20/x86_64/
-    - name: Fedora 20
-      url: http://dl.fedoraproject.org/pub/fedora/linux/releases/20/Fedora/x86_64/os/
-  - name: epel-7
-    buildsys: copr/jruzicka/rdo-juno-epel-7
-    distrepos:
-    - name: RDO Juno epel-7
-      url: https://repos.fedorapeople.org/repos/openstack/openstack-juno/epel-7/
-    - name: CentOS 7 Base
-      url: http://mirror.centos.org/centos/7/os/x86_64/
-    - name: CentOS 7 Updates
-      url: http://mirror.centos.org/centos/7/updates/x86_64/
-    - name: CentOS 7 Extras
-      url: http://mirror.centos.org/centos/7/extras/x86_64/
-    - name: EPEL 7
-      url: http://dl.fedoraproject.org/pub/epel/7/x86_64/
 
 
 # default template for 'packages' infromation bellow


### PR DESCRIPTION
Juno is EOL
Liberty and Kilo are EL7 only and hosted in CentOS CloudSIG
