### PR TITLE
gnocchi 2.0 is mitaka

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -114,6 +114,7 @@ packages:
   conf: core
   tags:
     mitaka:
+      source-branch: stable/2.0
     liberty:
       source-branch: stable/1.3
   maintainers:


### PR DESCRIPTION
`pradk` apevec, yes 2.0 is mitaka compatible