### PR TITLE
Add trove and sahara dashboard

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -418,6 +418,21 @@ packages:
   conf: core
   maintainers:
   - hguemar@redhat.com
+- project: trove-dashboard
+  name: openstack-trove-ui
+  tags:
+    mitaka:
+  conf: core
+  maintainers:
+  - victoria@redhat.com
+  - pmackinn@redhat.com
+- project: sahara-dashboard
+  name: openstack-sahara-ui
+  tags:
+    mitaka:
+  conf: core
+  maintainers:
+  - egafford@redhat.com
 # The openstack clients
 - project: keystoneclient
   conf: client


### PR DESCRIPTION
Please review @egafford @pdmack @vkmc

```
dlrn --info-repo ~/.rdopkg/rdoinfo --config-file projects.ini  --package-name openstack-sahara-ui
INFO:dlrn:Getting git://github.com/openstack-packages/sahara-dashboard to ./data/openstack-sahara-ui_distro
INFO:dlrn:Getting git://git.openstack.org/openstack/sahara-dashboard to ./data/openstack-sahara-ui
INFO:dlrn:Processing openstack-sahara-ui 466690137f6ee6b4445ee1effd6bd13e87901340
INFO:dlrn:128 packages not built correctly: not updating the consistent symlink
% dlrn --info-repo ~/.rdopkg/rdoinfo --config-file projects.ini  --package-name openstack-trove-ui 
INFO:dlrn:Getting git://github.com/openstack-packages/trove-dashboard to ./data/openstack-trove-ui_distro
INFO:dlrn:Getting git://git.openstack.org/openstack/trove-dashboard to ./data/openstack-trove-ui
INFO:dlrn:Processing openstack-trove-ui 7ff6706b09d1375de7726e9fb948babd56792d02
INFO:dlrn:127 packages not built correctly: not updating the consistent symlink
% ls data/repos/current 
build.log                                                           openstack-sahara-ui-4.0.0.0-0.20160413183229.4666901.el7.centos.noarch.rpm  python-oslotest-2.3.1-0.20160317151307.4150952.fc23.src.rpm
delorean.repo                                                       openstack-sahara-ui-4.0.0.0-0.20160413183229.4666901.el7.centos.src.rpm     repodata
installed                                                           openstack-trove-ui-6.0.0.0-0.20160413183746.7ff6706.el7.centos.noarch.rpm   root.log
mock.log                                                            openstack-trove-ui-6.0.0.0-0.20160413183746.7ff6706.el7.centos.src.rpm      rpmbuild.log
openstack-manila-ui-2.0.0-0.20160222174515.bf38208.fc23.noarch.rpm  python2-oslotest-2.3.1-0.20160317151307.4150952.fc23.noarch.rpm             state.log
openstack-manila-ui-2.0.0-0.20160222174515.bf38208.fc23.src.rpm     python3-oslotest-2.3.1-0.20160317151307.4150952.fc23.noarch.rpm             versions.csv
```