### PR TITLE
Set proper conf for k8sclient

### DIFF
--- a/rdo.yml
+++ b/rdo.yml
@@ -954,6 +954,6 @@ packages:
 - project: k8sclient
   tags:
     newton:
-  conf: lib
+  conf: client
   maintainers:
     - chkumar@redhat.com


### PR DESCRIPTION
Being "lib", its repo would become github.com/openstack/k8sclient. It
needs to be "client", so it is github.com/openstack/python-k8sclient.