### PR TITLE
Gnocchi requires cradox>=2.0.0

### DIFF
--- a/deps.yml
+++ b/deps.yml
@@ -645,9 +645,9 @@ packages:
   buildsys-tags:
     cloud7-openstack-common-testing: python-cradox-1.3.2-1.el7
     cloud7-openstack-common-release: python-cradox-1.3.2-1.el7
-    cloud7-openstack-queens-testing: python-cradox-1.3.2-1.el7
-    cloud7-openstack-queens-release: python-cradox-1.3.2-1.el7
-    cloud7-openstack-rocky-testing: python-cradox-1.3.2-1.el7
+    cloud7-openstack-queens-testing: python-cradox-2.0.7-1.el7
+    cloud7-openstack-queens-release: python-cradox-2.0.7-1.el7
+    cloud7-openstack-rocky-testing: python-cradox-2.0.7-1.el7
 - project: python-gmpy2
   name: python-gmpy2
   conf: fedora-dependency


### PR DESCRIPTION
Due to [1], we need to update python-cradox to >= 2.0.0.
This have also been done upstream [2].

https://github.com/gnocchixyz/gnocchi/pull/907
https://bugzilla.redhat.com/show_bug.cgi?id=1573878