### PR TITLE
Fixed 3 issues of type: PYTHON_W391 throughout 3 files in repo.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,3 @@ import setuptools
 setuptools.setup(
     setup_requires=['pbr'],
     pbr=True)
-

--- a/source/conf.py
+++ b/source/conf.py
@@ -150,6 +150,3 @@ texinfo_documents = [
      author, 'RDO', 'RDO packaging metadata.',
      'Miscellaneous'),
 ]
-
-
-

--- a/update-uc.py
+++ b/update-uc.py
@@ -125,4 +125,3 @@ def update_uc():
 
 if __name__ == '__main__':
     update_uc()
-


### PR DESCRIPTION
PYTHON_W391: 'blank line at end of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.