### PR TITLE
Define component for networking-generic-switch

### DIFF
--- a/tags/antelope.yml
+++ b/tags/antelope.yml
@@ -368,6 +368,7 @@ packages:
 - project: networking-generic-switch
   tags:
     antelope:
+      component: baremetal
 - project: networking-l2gw
   tags:
     antelope:


### PR DESCRIPTION
This PR updates the Antelope release metadata to accurately reflect the component for the networking-generic-switch project.

The component is now set to 'baremetal'.